### PR TITLE
Adds the ability to pass a manager to a NoticeHandler

### DIFF
--- a/Sources/NoticeMe/NoticeHandler.swift
+++ b/Sources/NoticeMe/NoticeHandler.swift
@@ -26,6 +26,11 @@ public struct NoticeHandler<Content: View>: View {
         self.content = content
     }
     
+    public init(_ manager: NoticeManager, content: @escaping () -> Content) {
+        self._manager = StateObject(wrappedValue: manager)
+        self.content = content
+    }
+    
     public var body: some View {
         content()
             .environment(\.noticeManager, manager)


### PR DESCRIPTION
This change is meant to allow sharing the same notices across multiple scopes. This includes being able to pass your manager to sheets, full screen covers, etc. Previously notices would not be able to be shared across these contexts.